### PR TITLE
now sessions apply within index view context

### DIFF
--- a/app/controllers/concerns/index_viewable.rb
+++ b/app/controllers/concerns/index_viewable.rb
@@ -27,7 +27,7 @@ module IndexViewable
   end
 
   def load_index_view
-    index_view_id = params[:index_view_id] || @search_session&.dig(:index_view_id)
+    index_view_id = params[:index_view_id] || @search_session&.index_view_id
     if index_view_id.present?
       index_view = @index_views.find_by(id: index_view_id)
       return index_view if index_view.present?

--- a/app/controllers/concerns/ransack_pagy_params.rb
+++ b/app/controllers/concerns/ransack_pagy_params.rb
@@ -1,0 +1,34 @@
+# RansackPagyParams
+#
+# This module provides methods for extracting and sanitizing parameters related to Ransack and Pagy.
+# It includes methods for querying parameters, sorting parameters, and page parameters.
+#
+module RansackPagyParams
+  extend ActiveSupport::Concern
+
+  private
+
+  def sanitized_query_params
+    if query_params.is_a?(ActionController::Parameters)
+      query_params.except(:s).permit!.to_h  # Ensure it's a permitted hash
+    else
+      {}
+    end
+  end
+
+  def page_params
+    params[:page]
+  end
+
+  def query_sort_params
+    params[:query]&.dig(:s)
+  end
+
+  def query_params
+    params[:query]
+  end
+
+  def index_view_id_params
+    params[:index_view_id]
+  end
+end

--- a/app/controllers/concerns/search_query_builder.rb
+++ b/app/controllers/concerns/search_query_builder.rb
@@ -1,0 +1,28 @@
+# SearchQueryBuilder
+#
+# This class is responsible for building a Ransack query based on the provided base query, search session, index view, and parameters.
+# It uses the search session for caching and the index view for filtering conditions.
+#
+class SearchQueryBuilder
+  def initialize(base_query, search_session, index_view, params)
+    @base_query = base_query
+    @search_session = search_session
+    @index_view = index_view
+    @params = params
+  end
+
+  def build
+    conditions = @index_view&.filter_conditions || {}
+    @base_query.ransack(query_criteria.merge(conditions)).apply_default_sorts(sort_criteria)
+  end
+
+  private
+
+  def query_criteria
+    CacheConfig.cache_enabled? ? @search_session.query : @params[:query]
+  end
+
+  def sort_criteria
+    CacheConfig.cache_enabled? ? @search_session.sort : @params[:query]&.dig(:s)
+  end
+end

--- a/app/models/application_cache.rb
+++ b/app/models/application_cache.rb
@@ -1,0 +1,89 @@
+# You can create additional subclasses as needed, for example:
+# class FilterSessionCache < ApplicationCache
+#   attr_accessor :filter_params
+#
+#   class << self
+#     private
+#
+#     def cache_prefix
+#       "filter_session"
+#     end
+#   end
+#
+#   private
+#
+#   def to_h
+#     super.merge(filter_params: @filter_params)
+#   end
+# end
+#
+class ApplicationCache
+  attr_reader :token
+
+  # Class-level methods
+  class << self
+    def read(controller_name, token)
+      cached_data = Rails.cache.read(cache_key(controller_name, token))
+      new(controller_name, token, cached_data)
+    end
+
+    def write(controller_name, token, attributes = {})
+      new(controller_name, token, attributes).tap(&:save)
+    end
+
+    private
+
+    def cache_key(controller_name, token)
+      "#{cache_prefix}_#{controller_name}_#{token}"
+    end
+
+    def cache_prefix
+      throw NotImplementedError, "Subclass must implement cache_prefix"
+    end
+  end
+
+  # Instance-level methods
+  def initialize(controller_name, token, attributes = {})
+    @controller_name = controller_name
+    @token = token
+    @original_attributes = attributes
+    self.attributes = attributes
+  end
+
+  def not_found?
+    @original_attributes.nil? || @original_attributes.empty?
+  end
+
+  def found?
+    !not_found?
+  end
+
+  def attributes=(attrs)
+    return unless attrs
+
+    attrs.each do |key, value|
+      if respond_to?(:"#{key}=")
+        instance_variable_set(:"@#{key}", value)
+      end
+    end
+  end
+
+  def save
+    Rails.cache.write(cache_key, to_h, expires_in: 1.hour)
+  end
+
+  def update(attributes)
+    self.attributes = attributes
+    save
+  end
+
+  private
+
+  def cache_key
+    self.class.send(:cache_key, @controller_name, @token)
+  end
+
+  def to_h
+    {token: @token}
+  end
+end

--- a/app/models/search_session_cache.rb
+++ b/app/models/search_session_cache.rb
@@ -1,0 +1,30 @@
+class SearchSessionCache < ApplicationCache
+  attr_accessor :query, :sort, :page, :index_view_id
+
+  class << self
+    private
+
+    def cache_prefix
+      "search_session"
+    end
+  end
+
+  def query_attributes
+    {
+      query: @query,
+      sort: @sort,
+      page: @page
+    }
+  end
+
+  private
+
+  def to_h
+    super.merge(
+      query: @query,
+      sort: @sort,
+      page: @page,
+      index_view_id: @index_view_id
+    )
+  end
+end

--- a/app/models/search_session_index_cache.rb
+++ b/app/models/search_session_index_cache.rb
@@ -1,0 +1,29 @@
+class SearchSessionIndexCache < ApplicationCache
+  attr_accessor :query, :sort, :page
+
+  class << self
+    private
+
+    def cache_prefix
+      "search_session_index"
+    end
+  end
+
+  def query_attributes
+    {
+      query: @query,
+      sort: @sort,
+      page: @page
+    }
+  end
+
+  private
+
+  def to_h
+    super.merge(
+      query: @query,
+      sort: @sort,
+      page: @page
+    )
+  end
+end


### PR DESCRIPTION
It makes more sense that in each index view tab your search box, page and sort apply in the context of that tab rather than be maintained between tabs. 

These changes accommodate that by also caching the at index_view level.