### PR TITLE
update linter to be standardrb + rubocop_rails + rubocop__minitest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           bundler-cache: true
 
       - name: Lint code for consistent style
-        run: bin/standardrb
+        run: bin/rubocop -f github
 
   test:
     runs-on: ubuntu-latest

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,22 @@
-# Omakase Ruby styling for Rails
-inherit_gem: { rubocop-rails-omakase: rubocop.yml }
+require:
+  - standard
+  - rubocop-rails
+  - rubocop-minitest
 
-# Overwrite or add rules to create your own house style
-#
-# # Use `[a, [b, c]]` not `[ a, [ b, c ] ]`
-# Layout/SpaceInsideArrayLiteralBrackets:
-#   Enabled: false
+inherit_gem:
+  standard: config/base.yml
+
+AllCops:
+  NewCops: enable
+  Exclude:
+    - node_modules/**/*
+    - public/**/*
+    - vendor/**/*  
+    - db/**/*
+
+Rails:
+  Enabled: true # enable rubocop-rails cops
+Minitest:
+  Enabled: true # enable rubocop-minitest cops
+Minitest/MultipleAssertions:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -49,9 +49,9 @@ group :development, :test do
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
 
-  # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
-  gem "rubocop-rails-omakase", require: false
   gem "standard"
+  gem "rubocop-rails", require: false
+  gem "rubocop-minitest", require: false
   gem "pry"
   gem "pry-remote"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,11 +305,6 @@ GEM
       rack (>= 1.1)
       rubocop (>= 1.52.0, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
-    rubocop-rails-omakase (1.0.0)
-      rubocop
-      rubocop-minitest
-      rubocop-performance
-      rubocop-rails
     ruby-progressbar (1.13.0)
     rubyzip (2.3.2)
     securerandom (0.3.1)
@@ -423,7 +418,8 @@ DEPENDENCIES
   ransack
   redcarpet
   rouge
-  rubocop-rails-omakase
+  rubocop-minitest
+  rubocop-rails
   selenium-webdriver
   solid_cable
   solid_cache

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   end
 
   def respond_with_csv(records, index_view)
-    filename = [index_view.name, Date.today.to_s].join(" ") + ".csv"
+    filename = [index_view.name, Time.zone.today.to_s].join(" ") + ".csv"
     send_data index_view.generate_csv(records), filename: filename, content_type: "text/csv"
   end
 

--- a/app/controllers/concerns/index_viewable.rb
+++ b/app/controllers/concerns/index_viewable.rb
@@ -3,8 +3,11 @@ module IndexViewable
 
   class_methods do
     def index_viewable(model_class)
+      # Disable the Rails/LexicallyScopedActionFilter cop for this block
+      # rubocop:disable Rails/LexicallyScopedActionFilter
       before_action -> { set_index_views(model_class) }, only: [:index]
       before_action :set_index_view, only: [:index]
+      # rubocop:enable Rails/LexicallyScopedActionFilter
     end
   end
 
@@ -13,11 +16,7 @@ module IndexViewable
   def set_index_views(model_class)
     @user = Current.user
     table_entity = model_class.table_entity
-    # print "Current.user: #{Current.user.inspect}"
-    # print "Current.user.index_views: #{Current.user.index_views.inspect}"
-    #  print "table_entity: #{table_entity.inspect}"
-    #  print "All Table Entities: #{TableEntity.all.inspect}"
-    #  print "#{model_class.name} Table Entity: #{table_entity.inspect}"
+
     @index_views = Current.user.index_views.where(table_entity: table_entity)
       .order(default: :desc, name: :asc)
   end

--- a/app/controllers/concerns/search_session_manageable.rb
+++ b/app/controllers/concerns/search_session_manageable.rb
@@ -124,7 +124,7 @@ module SearchSessionManageable
   end
 
   def set_search_session_index_view_id(index_view)
-    return unless index_view.present?
+    return if index_view.blank?
     new_index_view_id = index_view.id
     if @search_session.index_view_id != new_index_view_id
       @search_session.update(index_view_id: new_index_view_id.to_s)

--- a/app/controllers/documents/fragments_controller.rb
+++ b/app/controllers/documents/fragments_controller.rb
@@ -1,19 +1,7 @@
 class Documents::FragmentsController < ApplicationController
   before_action :set_fragment, only: [:update, :show, :destroy]
 
-  def update
-    @fragment.update(fragment_params)
-    @fragment.saved = true
-
-    redirect_to document_fragment_path(@fragment.document_id, @fragment.id)
-  end
-
   def show
-  end
-
-  def destroy
-    @fragment.destroy
-    redirect_to with_search_session_token(edit_document_path(@fragment.document_id))
   end
 
   def create
@@ -23,6 +11,18 @@ class Documents::FragmentsController < ApplicationController
       @fragment.save
     end
     redirect_to(with_search_session_token(edit_document_path(@fragment.document_id, select_fragment: @fragment.reload.id)))
+  end
+
+  def update
+    @fragment.update(fragment_params)
+    @fragment.saved = true
+
+    redirect_to document_fragment_path(@fragment.document_id, @fragment.id)
+  end
+
+  def destroy
+    @fragment.destroy
+    redirect_to with_search_session_token(edit_document_path(@fragment.document_id))
   end
 
   private

--- a/app/controllers/index_views/filters_controller.rb
+++ b/app/controllers/index_views/filters_controller.rb
@@ -13,6 +13,9 @@ class IndexViews::FiltersController < ApplicationController
     @filter = @index_view.filters.new
   end
 
+  def edit
+  end
+
   def create
     @filter = @index_view.filters.new(filter_params)
     if @filter.save
@@ -20,9 +23,6 @@ class IndexViews::FiltersController < ApplicationController
     else
       render :new
     end
-  end
-
-  def edit
   end
 
   def update

--- a/app/controllers/index_views_controller.rb
+++ b/app/controllers/index_views_controller.rb
@@ -7,14 +7,14 @@ class IndexViewsController < ApplicationController
     @index_views = Current.user.index_views.where(table_entity: @table_entity).order(:name)
   end
 
+  def show
+  end
+
   def new
     @index_view = IndexView.new(table_entity: @table_entity)
   end
 
   def edit
-  end
-
-  def show
   end
 
   def create

--- a/app/models/application_cache.rb
+++ b/app/models/application_cache.rb
@@ -51,7 +51,7 @@ class ApplicationCache
   end
 
   def not_found?
-    @original_attributes.nil? || @original_attributes.empty?
+    @original_attributes.blank?
   end
 
   def found?

--- a/app/models/concerns/has_table_configuration.rb
+++ b/app/models/concerns/has_table_configuration.rb
@@ -53,7 +53,7 @@ module HasTableConfiguration
     end
 
     def remove_unused_columns
-      default_attributes = default_table_columns.map { |columns| columns[:attribute_name] }
+      default_attributes = default_table_columns.pluck(:attribute_name)
       table_columns.where.not(attribute_name: default_attributes).destroy_all
     end
   end

--- a/app/models/index_view.rb
+++ b/app/models/index_view.rb
@@ -31,8 +31,8 @@ class IndexView < ApplicationRecord
   belongs_to :active_filter, class_name: "Filter", optional: true
   has_many :filters, dependent: :destroy
   has_many :index_view_columns, dependent: :destroy
-  has_many :displayed_index_view_columns, -> { displayed.order(:position) }, class_name: "IndexViewColumn"
-  has_many :hidden_index_view_columns, -> { hidden.order(:position) }, class_name: "IndexViewColumn"
+  has_many :displayed_index_view_columns, -> { displayed.order(:position) }, class_name: "IndexViewColumn", dependent: :destroy, inverse_of: :index_view
+  has_many :hidden_index_view_columns, -> { hidden.order(:position) }, class_name: "IndexViewColumn", dependent: :destroy, inverse_of: :index_view
   accepts_nested_attributes_for :index_view_columns, allow_destroy: true
 
   delegate :model_class_name, to: :table_entity, prefix: true
@@ -87,13 +87,13 @@ class IndexView < ApplicationRecord
 
   class << self
     def create_default_views
-      User.all.each do |user|
+      User.find_each do |user|
         create_default_views_for_user(user)
       end
     end
 
     def create_default_views_for_user(user)
-      TableEntity.all.each do |table_entity|
+      TableEntity.find_each do |table_entity|
         index_view = find_or_create_by(default: true, table_entity: table_entity, user: user) do |index_view|
           index_view.name = "Default view"
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@
 #  updated_at :datetime         not null
 #
 class User < ApplicationRecord
-  has_many :index_views
+  has_many :index_views, dependent: :destroy
 
   def self.ransackable_attributes(auth_object = nil)
     ["created_at", "email", "logged_in", "name", "updated_at"]

--- a/app/services/markdown_renderer.rb
+++ b/app/services/markdown_renderer.rb
@@ -16,7 +16,7 @@ module MarkdownRenderer
 
   def self.md_to_html(content, assigns = {})
     # Render the result via Redcarpet, using our Custom Renderer
-    Redcarpet::Markdown.new(
+    rendered_content = Redcarpet::Markdown.new(
       CustomHTML.new(link_attributes: {target: "_blank", rel: "noopener"}),
       fenced_code_blocks: true,
       autolink: true,
@@ -25,6 +25,16 @@ module MarkdownRenderer
       space_after_headers: false,
       highlight: true,
       with_toc_data: true
-    ).render(content).html_safe
+    ).render(content)
+
+    ActionController::Base.helpers.sanitize(rendered_content, tags: allowed_tags, attributes: allowed_attributes)
+  end
+
+  def self.allowed_tags
+    %w[p br img h1 h2 h3 h4 h5 h6 strong em del pre code blockquote ol ul li a span div]
+  end
+
+  def self.allowed_attributes
+    %w[href src alt title class]
   end
 end

--- a/bin/bundle
+++ b/bin/bundle
@@ -39,7 +39,7 @@ m = Module.new do
 
   def gemfile
     gemfile = ENV["BUNDLE_GEMFILE"]
-    return gemfile if gemfile && !gemfile.empty?
+    return gemfile if gemfile.present?
 
     File.expand_path("../Gemfile", __dir__)
   end

--- a/bin/setup
+++ b/bin/setup
@@ -4,8 +4,8 @@ require "fileutils"
 APP_ROOT = File.expand_path("..", __dir__)
 APP_NAME = "hotwirestack"
 
-def system!(*args)
-  system(*args, exception: true)
+def system!(*)
+  system(*, exception: true)
 end
 
 FileUtils.chdir APP_ROOT do
@@ -32,7 +32,7 @@ FileUtils.chdir APP_ROOT do
 
   unless ARGV.include?("--skip-server")
     puts "\n== Starting development server =="
-    STDOUT.flush # flush the output before exec(2) so that it displays
+    $stdout.flush # flush the output before exec(2) so that it displays
     exec "bin/dev"
   end
 end

--- a/config/initializers/cache_config.rb
+++ b/config/initializers/cache_config.rb
@@ -1,5 +1,5 @@
 module CacheConfig
   def self.cache_enabled?
-    !Rails.env.development? || File.exist?(Rails.root.join("tmp", "caching-dev.txt"))
+    !Rails.env.development? || Rails.root.join("tmp/caching-dev.txt").exist?
   end
 end

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -3,7 +3,7 @@
 # NOTE: to have a dev-mode tool do its thing in production.
 if Rails.env.development?
   require "annotate"
-  task :set_annotation_options do
+  task set_annotation_options: :environment do
     # You can override any of these by setting an environment variable of the
     # same name.
     Annotate.set_defaults(

--- a/lib/tasks/fixture_generator.rake
+++ b/lib/tasks/fixture_generator.rake
@@ -24,7 +24,7 @@ namespace :fixture_generator do
 
     puts tables_hash.to_yaml
 
-    File.write("#{Rails.root}/test/fixtures/table_entities.yml", tables_hash.to_yaml)
+    File.write(Rails.root.join("test/fixtures/table_entities.yml").to_s, tables_hash.to_yaml)
   end
 
   task table_columns: :environment do
@@ -52,7 +52,7 @@ namespace :fixture_generator do
 
     puts columns_hash.to_yaml
 
-    File.write("#{Rails.root}/test/fixtures/table_columns.yml", columns_hash.to_yaml)
+    File.write(Rails.root.join("test/fixtures/table_columns.yml").to_s, columns_hash.to_yaml)
   end
 
   task index_views: :environment do
@@ -80,7 +80,7 @@ namespace :fixture_generator do
 
     puts index_views_hash.to_yaml
 
-    File.write("#{Rails.root}/test/fixtures/index_views.yml", index_views_hash.to_yaml)
+    File.write(Rails.root.join("test/fixtures/index_views.yml").to_s, index_views_hash.to_yaml)
   end
 
   task index_view_columns: :environment do
@@ -107,7 +107,7 @@ namespace :fixture_generator do
 
     puts index_view_columns_hash.to_yaml
 
-    File.write("#{Rails.root}/test/fixtures/index_view_columns.yml", index_view_columns_hash.to_yaml)
+    File.write(Rails.root.join("test/fixtures/index_view_columns.yml").to_s, index_view_columns_hash.to_yaml)
   end
 
   task filters: :environment do
@@ -133,13 +133,13 @@ namespace :fixture_generator do
 
     puts filters_hash.to_yaml
 
-    File.write("#{Rails.root}/test/fixtures/filters.yml", filters_hash.to_yaml)
+    File.write(Rails.root.join("test/fixtures/filters.yml").to_s, filters_hash.to_yaml)
   end
 
   task active_filters: :environment do
     require "yaml"
 
-    tables = TableEntity.where(id: TableColumn.where(attribute_name: "active").pluck(:table_entity_id))
+    tables = TableEntity.where(id: TableColumn.where(attribute_name: "active").select(:table_entity_id))
     filter_conditional_group_hash = {}
     filter_condition_hash = {}
     tables.each do |table|
@@ -167,7 +167,7 @@ namespace :fixture_generator do
 
     puts filter_conditional_group_hash.to_yaml
     puts filter_condition_hash.to_yaml
-    File.write("#{Rails.root}/test/fixtures/filter_conditional_groups.yml", filter_conditional_group_hash.to_yaml)
-    File.write("#{Rails.root}/test/fixtures/filter_conditions.yml", filter_condition_hash.to_yaml)
+    File.write(Rails.root.join("test/fixtures/filter_conditional_groups.yml").to_s, filter_conditional_group_hash.to_yaml)
+    File.write(Rails.root.join("test/fixtures/filter_conditions.yml").to_s, filter_condition_hash.to_yaml)
   end
 end

--- a/lib/tasks/tasks.routes.rake
+++ b/lib/tasks/tasks.routes.rake
@@ -1,3 +1,3 @@
-task :routes do
+task routes: :environment do
   puts `bin/rails routes`
 end

--- a/test/components/forms/error_message_component_test.rb
+++ b/test/components/forms/error_message_component_test.rb
@@ -8,6 +8,7 @@ class Forms::ErrorMessageComponentTest < ViewComponent::TestCase
     component = Forms::ErrorMessageComponent.new(model)
 
     render_inline(component)
+
     assert_no_selector "div", id: "error_explanation"
   end
 
@@ -17,6 +18,7 @@ class Forms::ErrorMessageComponentTest < ViewComponent::TestCase
     component = Forms::ErrorMessageComponent.new(model)
 
     render_inline(component)
+
     assert_selector "div", id: "error_explanation"
     assert_selector "ul", count: 1
     assert_selector "li", text: "Title can't be blank"

--- a/test/components/forms/fields_container_component_test.rb
+++ b/test/components/forms/fields_container_component_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 class Forms::FieldsContainerComponentTest < ViewComponent::TestCase
   def test_renders_fields_container
     render_inline(Forms::FieldsContainerComponent.new(model: Document.new))
+
     assert_selector "div", count: 2
   end
 end

--- a/test/components/forms/nested_add_link_component_test.rb
+++ b/test/components/forms/nested_add_link_component_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 class Forms::NestedAddLinkComponentTest < ViewComponent::TestCase
   def test_link_component_renders
     render_inline(Forms::NestedAddLinkComponent.new("Add"))
+
     assert_selector "a", text: "Add"
     assert_selector "a[href='#']"
     assert_selector "a[data-action='click->nested-form#add_association']"

--- a/test/components/forms/select_input_component_test.rb
+++ b/test/components/forms/select_input_component_test.rb
@@ -20,6 +20,7 @@ class Forms::SelectInputComponentTest < ViewComponent::TestCase
     component = Forms::SelectInputComponent.new(form, :field_name, options: options)
 
     render_inline(component)
+
     assert_selector "select"
     form.verify
   end

--- a/test/components/forms/text_input_component_test.rb
+++ b/test/components/forms/text_input_component_test.rb
@@ -29,11 +29,13 @@ class Forms::TextInputComponentTest < ViewComponent::TestCase
       render_inline(Forms::FieldComponent.new(form, @field)) do |field|
         field.with_input_text(rounded: true)
       end
+
       assert_selector 'input[type="text"]', class: /\brounded-md\b/
 
       render_inline(Forms::FieldComponent.new(form, @field)) do |field|
         field.with_input_text(rounded: false)
       end
+
       assert_selector 'input[type="text"]', class: /\brounded-none\b/
     end
   end
@@ -46,6 +48,7 @@ class Forms::TextInputComponentTest < ViewComponent::TestCase
         field.with_input_number(placeholder: "Enter title", autocomplete: "on", autofocus: true)
       end
     end
+
     assert_selector 'input[type="number"][placeholder="Enter title"][autocomplete="on"][autofocus]'
   end
 end

--- a/test/components/header/cache_status_component_test.rb
+++ b/test/components/header/cache_status_component_test.rb
@@ -6,20 +6,23 @@ class Header::CacheStatusComponentTest < ViewComponent::TestCase
   def test_component_does_not_render_when_cache_is_enabled
     redefine_cache_enabled(true) do
       component = Header::CacheStatusComponent.new
-      refute component.render?
+
+      assert_not component.render?
     end
   end
 
   def test_component_renders_when_cache_is_disabled
     redefine_cache_enabled(false) do
       component = Header::CacheStatusComponent.new
-      assert component.render?
+
+      assert_predicate component, :render?
     end
   end
 
   def test_component_content
     redefine_cache_enabled(false) do
       render_inline(Header::CacheStatusComponent.new)
+
       assert_selector "div", class: "text-sm pl-4 text-red-500"
       assert_selector "p", text: "Cache is disabled"
     end

--- a/test/components/header/logo_component_test.rb
+++ b/test/components/header/logo_component_test.rb
@@ -5,6 +5,7 @@ require "test_helper"
 class Header::LogoComponentTest < ViewComponent::TestCase
   def test_render_logo_component
     render_inline(Header::LogoComponent.new)
+
     assert_selector "div", class: "flex lg:flex-1"
     assert_selector "img", class: "h-8 w-auto"
     assert_selector "a[href='/']"

--- a/test/components/header/main_component_test.rb
+++ b/test/components/header/main_component_test.rb
@@ -6,6 +6,7 @@ class Header::MainComponentTest < ViewComponent::TestCase
   def test_component_renders_something_useful
     current_path = "/"
     render_inline(Header::MainComponent.new(current_path: current_path))
+
     assert_selector "a[href='/documents']"
     assert_selector "a[href='/about/index']"
   end

--- a/test/components/index/clear_filter_button_component_test.rb
+++ b/test/components/index/clear_filter_button_component_test.rb
@@ -11,6 +11,7 @@ class Index::ClearFilterButtonComponentTest < ViewComponent::TestCase
 
   test "renders component" do
     render_inline(Index::ClearFilterButtonComponent.new(index_view: @index_view, search_session_token: @search_session))
+
     assert_selector "form[action='/index_views/#{@index_view.id}/active_filter?search_session_token=#{@search_session}']"
     assert_selector "span", text: "Clear filter"
   end

--- a/test/components/index/column_config_dropdown_component_test.rb
+++ b/test/components/index/column_config_dropdown_component_test.rb
@@ -9,6 +9,7 @@ class Index::ColumnConfigDropdownComponentTest < ViewComponent::TestCase
 
   def test_component_renders_button
     render_inline(Index::ColumnConfigDropdownComponent.new(index_view: @index_view, refresh_frame: "freshing", refresh_path: "pathing", search_session_token: "XXXXXXX"))
+
     assert_selector "button"
     assert_selector "div[data-reload-dropdown-frame-value='index_view_#{@index_view.id}']"
     assert_selector "div[data-reload-dropdown-refresh-path-value='pathing']"

--- a/test/components/index/config_dropdowns_component_test.rb
+++ b/test/components/index/config_dropdowns_component_test.rb
@@ -9,6 +9,7 @@ class Index::ConfigDropdownsComponentTest < ViewComponent::TestCase
 
   def test_buttons_renders
     render_inline(Index::ConfigDropdownsComponent.new(index_view: @index_view, refresh_frame: "freshing", refresh_path: "pathing", search_session_token: "XXXXXXX"))
+
     assert_selector "button", count: 2
   end
 end

--- a/test/components/index/filter_config_dropdown_component_test.rb
+++ b/test/components/index/filter_config_dropdown_component_test.rb
@@ -9,6 +9,7 @@ class Index::FilterConfigDropdownComponentTest < ViewComponent::TestCase
 
   def test_component_renders_button
     render_inline(Index::FilterConfigDropdownComponent.new(index_view: @index_view, refresh_frame: "freshing", refresh_path: "pathing", search_session_token: "XXXXXXX"))
+
     assert_selector "button"
     assert_selector "div[data-dropdown-frame-value='index_view_#{@index_view.id}']"
     assert_selector "div[data-dropdown-refresh-path-value='pathing']"

--- a/test/components/index/tabs_component_test.rb
+++ b/test/components/index/tabs_component_test.rb
@@ -7,6 +7,7 @@ class Index::TabsComponentTest < ViewComponent::TestCase
     @index_views = [index_views(:index_view_document_one_all), index_views(:index_view_document_one_active_only)]
     @selected_index_view = index_views(:index_view_document_one_all)
     render_inline(Index::TabsComponent.new(:documents_path, @index_views, @selected_index_view, "XXXXX"))
+
     assert_selector "div.flex"
   end
 end

--- a/test/controllers/about_controller_test.rb
+++ b/test/controllers/about_controller_test.rb
@@ -3,9 +3,11 @@ require "test_helper"
 class AboutControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
     get about_index_url
+
     assert_response :success
     assert_equal User.where(logged_in: true).first, assigns(:user)
     index_views = assigns(:index_views)
+
     assert_equal 2, index_views.count
   end
 end

--- a/test/controllers/boards_controller_test.rb
+++ b/test/controllers/boards_controller_test.rb
@@ -7,11 +7,13 @@ class BoardsControllerTest < ActionDispatch::IntegrationTest
 
   test "should get index" do
     get boards_path
+
     assert_response :success
   end
 
   test "should get new" do
     get new_board_path
+
     assert_response :success
   end
 
@@ -25,16 +27,19 @@ class BoardsControllerTest < ActionDispatch::IntegrationTest
 
   test "should show board" do
     get board_path(@board)
+
     assert_response :success
   end
 
   test "should get edit" do
     get edit_board_path(@board)
+
     assert_response :success
   end
 
   test "should update board" do
     patch board_path(@board), params: {search_session_token: "XXXXX", board: {active: @board.active, name: @board.name, owner_id: @board.owner_id}}
+
     assert_redirected_to boards_path(search_session_token: "XXXXX")
   end
 

--- a/test/controllers/documents_controller_test.rb
+++ b/test/controllers/documents_controller_test.rb
@@ -7,16 +7,19 @@ class DocumentsControllerTest < ActionDispatch::IntegrationTest
 
   test "index page displays documents" do
     get documents_path
+
     assert_response :success
   end
 
   test "index page displays documents 2" do
     get documents_path
+
     assert_response :success
   end
 
   test "should get new" do
     get new_document_path
+
     assert_response :success
   end
 
@@ -30,16 +33,19 @@ class DocumentsControllerTest < ActionDispatch::IntegrationTest
 
   test "should show document" do
     get document_path(@document)
+
     assert_response :success
   end
 
   test "should get edit" do
     get edit_document_path(@document)
+
     assert_response :success
   end
 
   test "should update document" do
     patch document_path(@document), params: {search_session_token: "XXXXX", document: {active: @document.active, title: @document.title}}
+
     assert_redirected_to documents_path(search_session_token: "XXXXX")
   end
 

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class HomeControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
     get root_path
+
     assert_response :success
   end
 end

--- a/test/controllers/index_views/active_filter_controller_test.rb
+++ b/test/controllers/index_views/active_filter_controller_test.rb
@@ -8,15 +8,19 @@ class IndexViews::ActiveFilterControllerTest < ActionDispatch::IntegrationTest
 
   test "should update" do
     patch index_view_active_filter_path(@index_view), params: {filter_id: @filter.id, search_session_token: "XXXXX"}
+
     assert_redirected_to documents_path(index_view_id: @index_view.id, search_session_token: "XXXXX")
 
     @index_view.reload
+
     assert_equal @filter, @index_view.active_filter
 
     patch index_view_active_filter_path(@index_view), params: {filter_id: nil, search_session_token: "XXXXX"}
+
     assert_redirected_to documents_path(index_view_id: @index_view.id, search_session_token: "XXXXX")
 
     @index_view.reload
+
     assert_nil @index_view.active_filter
   end
 end

--- a/test/controllers/index_views/filters_controller_test.rb
+++ b/test/controllers/index_views/filters_controller_test.rb
@@ -8,11 +8,13 @@ class IndexViews::FiltersControllerTest < ActionDispatch::IntegrationTest
 
   test "should get index" do
     get index_view_filters_path(@index_view)
+
     assert_response :success
   end
 
   test "should get new" do
     get new_index_view_filter_path(@index_view)
+
     assert_response :success
   end
 
@@ -25,11 +27,13 @@ class IndexViews::FiltersControllerTest < ActionDispatch::IntegrationTest
 
   test "should get edit" do
     get edit_index_view_filter_path(@index_view, @filter)
+
     assert_response :success
   end
 
   test "should update" do
     patch index_view_filter_path(@index_view, @filter), params: {filter: {name: "Updated Filter"}, search_session_token: "XXXXX"}
+
     assert_redirected_to documents_path(index_view_id: @index_view.id, search_session_token: "XXXXX")
   end
 

--- a/test/controllers/index_views_controller_test.rb
+++ b/test/controllers/index_views_controller_test.rb
@@ -8,11 +8,13 @@ class IndexViewsControllerTest < ActionDispatch::IntegrationTest
 
   test "should get show" do
     get index_view_path(@index_view)
+
     assert_response :success
   end
 
   test "should get new" do
     get new_index_view_path(table_entity_id: @table_entity.id)
+
     assert_response :success
   end
 

--- a/test/integration/documents_test.rb
+++ b/test/integration/documents_test.rb
@@ -11,10 +11,11 @@ class DocumentsTest < ActionDispatch::IntegrationTest
   end
 
   test "index page displays documents - with correct links - caching applied" do
-    assert CacheConfig.cache_enabled?, "Cache is not enabled"
+    assert_predicate CacheConfig, :cache_enabled?, "Cache is not enabled"
 
     get documents_path
     index_views = assigns(:index_views)
+
     assert_equal 2, index_views.count
     assert_equal User.where(logged_in: true).first, assigns(:user)
 
@@ -22,6 +23,7 @@ class DocumentsTest < ActionDispatch::IntegrationTest
 
     documents = assigns(:documents)
     search_session_token = assigns(:search_session).token
+
     assert_equal 4, documents.count
     assert_not_nil search_session_token
 
@@ -32,45 +34,62 @@ class DocumentsTest < ActionDispatch::IntegrationTest
     assert_select "form[action='#{document_path(documents(:one), search_session_token: search_session_token)}'][method='post']"
 
     get documents_path(index_view_id: @active_only_index_view.id, search_session_token: search_session_token)
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 4, documents.count
 
     patch index_view_active_filter_path(@active_only_index_view, filter_id: @filter.id, search_session_token: search_session_token)
+
     assert_redirected_to documents_path(index_view_id: @active_only_index_view.id, search_session_token: search_session_token)
     get documents_path(index_view_id: @active_only_index_view.id, search_session_token: search_session_token)
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 3, documents.count
     assert_select "a[href='#{edit_document_path(documents(:one), search_session_token: search_session_token)}']", text: "Edit", count: 0
     assert_select "form[action='#{document_path(documents(:one), search_session_token: search_session_token)}'][method='post']", count: 0
 
     patch index_view_active_filter_path(@active_only_index_view, filter_id: nil, search_session_token: search_session_token)
+
     assert_redirected_to documents_path(index_view_id: @active_only_index_view.id, search_session_token: search_session_token)
     get documents_path(index_view_id: @active_only_index_view.id, search_session_token: search_session_token)
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 4, documents.count
     get documents_path(search_session_token: search_session_token, query: {title_cont: "One"})
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 1, documents.count
 
     patch index_view_active_filter_path(@active_only_index_view, filter_id: @filter.id, search_session_token: search_session_token)
+
     assert_redirected_to documents_path(index_view_id: @active_only_index_view.id, search_session_token: search_session_token)
     follow_redirect!
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 0, documents.count
 
     patch index_view_active_filter_path(@active_only_index_view, filter_id: nil, search_session_token: search_session_token)
+
     assert_redirected_to documents_path(index_view_id: @active_only_index_view.id, search_session_token: search_session_token)
     follow_redirect!
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 1, documents.count
 
     get edit_document_path(documents(:one), search_session_token: search_session_token)
+
     assert_response :success
     # assert_select "input[type='hidden'][name='search_session_token'][value='#{search_session_token}']"
 
@@ -159,12 +178,15 @@ class DocumentsTest < ActionDispatch::IntegrationTest
 
   test "index page displays documents - add new index view and filters, edit it and then delete it" do
     get documents_path
+
     assert_response :success
     documents = assigns(:documents)
     search_session_token = assigns(:search_session).token
+
     assert_equal 4, documents.count
 
     get new_index_view_path(table_entity_id: @table_entity.id, search_session_token: search_session_token)
+
     assert_response :success
     assert_select "input[type='hidden'][name='search_session_token'][value='#{search_session_token}']"
 
@@ -174,10 +196,13 @@ class DocumentsTest < ActionDispatch::IntegrationTest
       end
     end
     index_view = IndexView.find_by(name: "Testing an new index view")
+
     assert_redirected_to documents_path(index_view_id: index_view.id, search_session_token: search_session_token)
     follow_redirect!
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 4, documents.count
 
     table_column = table_columns(:document_column_active)
@@ -193,77 +218,104 @@ class DocumentsTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to documents_path(index_view_id: index_view.id, search_session_token: search_session_token)
     follow_redirect!
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 1, documents.count, "filter applied"
 
     get index_views_path(table_entity_id: @table_entity.id, search_session_token: search_session_token)
+
     assert_response :success
     index_views = assigns(:index_views)
+
     assert_equal 3, index_views.count
     assert_select "a[href='#{edit_index_view_path(index_view, search_session_token: search_session_token)}']", text: "Edit"
 
     get edit_index_view_path(index_view, search_session_token: search_session_token)
+
     assert_response :success
     assert_select "input[type='hidden'][name='search_session_token'][value='#{search_session_token}']"
 
     patch index_view_path(index_view, search_session_token: search_session_token), params: {index_view: {name: "Updated Index View"}}
+
     assert_redirected_to documents_path(index_view_id: index_view.id, search_session_token: search_session_token)
     follow_redirect!
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 1, documents.count, "filter applied"
 
     get index_views_path(table_entity_id: @table_entity.id, search_session_token: search_session_token)
+
     assert_response :success
     index_views = assigns(:index_views)
+
     assert_equal 3, index_views.count
     assert_select "form[action='#{index_view_path(index_view, search_session_token: search_session_token)}'][method='post']", count: 1
 
     delete index_view_path(index_view, search_session_token: search_session_token)
+
     assert_redirected_to documents_path(index_view_id: index_view.id, search_session_token: search_session_token)
     follow_redirect!
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 4, documents.count, "back to default index view"
     search_session = assigns(:search_session)
+
     assert_equal @default_index_view.id.to_s, search_session.index_view_id
   end
 
   test "changing index_views and searcha and sort persisetance via search session" do
     @active_only_index_view.update(active_filter_id: @filter.id)
     get documents_path
+
     assert_response :success
     documents = assigns(:documents)
     search_session_token = assigns(:search_session).token
+
     assert_equal 4, documents.count
 
     get documents_path(search_session_token: search_session_token, query: {title_cont: "One", s: "title asc"})
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 1, documents.count
 
     get documents_path(index_view_id: @active_only_index_view.id, search_session_token: search_session_token)
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 3, documents.count
     search_session = assigns(:search_session)
+
     assert_nil search_session.sort
-    assert_equal({}, search_session.query.to_h)
+    assert_empty(search_session.query.to_h)
 
     get documents_path(search_session_token: search_session_token, query: {title_cont: "Three"})
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 1, documents.count
     search_session = assigns(:search_session)
+
     assert_nil search_session.sort
     assert_equal({"title_cont" => "Three"}, search_session.query.to_h)
 
     get documents_path(index_view_id: @default_index_view.id, search_session_token: search_session_token)
+
     assert_response :success
     documents = assigns(:documents)
+
     assert_equal 1, documents.count
     search_session = assigns(:search_session)
+
     assert_equal({"title_cont" => "One"}, search_session.query.to_h)
     assert_equal("title asc", search_session.sort)
   end

--- a/test/system/boards_test.rb
+++ b/test/system/boards_test.rb
@@ -7,6 +7,7 @@ class BoardsTest < ApplicationSystemTestCase
 
   test "visiting the index" do
     visit boards_path
+
     assert_selector "h1", text: "Boards"
   end
 

--- a/test/system/documents_test.rb
+++ b/test/system/documents_test.rb
@@ -7,6 +7,7 @@ class DocumentsTest < ApplicationSystemTestCase
 
   test "visiting the index" do
     visit documents_path
+
     assert_selector "h1", text: "Documents"
   end
 
@@ -33,6 +34,7 @@ class DocumentsTest < ApplicationSystemTestCase
     visit documents_path
     click_on "Delete", match: :first
     accept_confirm
+
     assert_text "Document was successfully destroyed"
   end
 end


### PR DESCRIPTION
We have to tell RuboCop which extensions we want to use, so, at the beginning of the .rubocop.yml file we add:

require:
  - standard
  - rubocop-rails
  - rubocop-rspec